### PR TITLE
Fix issues 72 and 71.

### DIFF
--- a/administracion/test_views.py
+++ b/administracion/test_views.py
@@ -45,6 +45,7 @@ class TestViewsAdministracion(StaticLiveServerTestCase):
         """At the end of tests, close the browser.
 
         """
+        self.browser.driver.close()
         self.browser.quit()
 
     def test_main_dashboard(self):
@@ -333,6 +334,7 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
     def tearDown(self):
         """ At the end of tests, close the browser.
         """
+        self.browser.driver.close()
         self.browser.quit()
 
     def test_if_not_exist_any_studies_rejected(self):
@@ -552,7 +554,7 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
         self.assertTrue(self.browser.is_text_present('Familia'))
         self.assertTrue(self.browser.is_text_present('Nombre del Capturista'))
         self.assertTrue(self.browser.is_text_present('Ver'))
-        self.assertTrue(self.browser.is_text_present('aprobado'))
+        self.assertTrue(self.browser.is_text_present('Aprobado'))
 
     def test_if_not_exist_any_draft_studies(self):
         """ Test for url 'administracion:main_estudios' with the 'borrador' parameter.
@@ -625,7 +627,7 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
         self.assertTrue(self.browser.is_text_present('Familia'))
         self.assertTrue(self.browser.is_text_present('Nombre del Capturista'))
         self.assertTrue(self.browser.is_text_present('Ver'))
-        self.assertTrue(self.browser.is_text_present('borrador'))
+        self.assertTrue(self.browser.is_text_present('Borrador'))
 
     def test_if_not_exist_any_studies_deleted(self):
         """ Test for url 'administracion:main_estudios' with the 'eliminado' parameter.
@@ -698,4 +700,4 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
         self.assertTrue(self.browser.is_text_present('Familia'))
         self.assertTrue(self.browser.is_text_present('Nombre del Capturista'))
         self.assertTrue(self.browser.is_text_present('Ver'))
-        self.assertTrue(self.browser.is_text_present('eliminado'))
+        self.assertTrue(self.browser.is_text_present('Eliminado'))

--- a/administracion/views.py
+++ b/administracion/views.py
@@ -14,8 +14,7 @@ def admin_main_dashboard(request):
     """View to render the main control dashboard.
 
     """
-    return render(request, 'administracion/dashboard_administrador.html',
-                  {'status_options': Estudio.get_options_status()})
+    return render(request, 'administracion/dashboard_administrador.html')
 
 
 @login_required
@@ -29,8 +28,7 @@ def admin_users_dashboard(request):
 
     return render(request, 'administracion/crud_users.html',
                   {'all_users': users,
-                   'create_user_form': create_user_form,
-                   'status_options': Estudio.get_options_status()})
+                   'create_user_form': create_user_form})
 
 
 @login_required
@@ -120,7 +118,7 @@ def focus_mode(request, study_id):
 
     TODO: This should be filled with all the info of the study.
     """
-    context = {'status_options': Estudio.get_options_status()}
+    context = {}
     estudio = Estudio.objects.get(pk=study_id)
     if estudio.status == Estudio.REVISION:
         feedback_form = FeedbackForm(initial={'estudio': estudio,

--- a/base/test_views.py
+++ b/base/test_views.py
@@ -29,6 +29,7 @@ class TestBaseViews(StaticLiveServerTestCase):
     def tearDown(self):
         """At the end of tests, close the browser
         """
+        self.browser.driver.close()
         self.browser.quit()
 
     # def test_home(self):

--- a/captura/test_views.py
+++ b/captura/test_views.py
@@ -71,6 +71,7 @@ class TestViewsCapturaEstudio(StaticLiveServerTestCase):
         self.browser.find_by_id('login-submit').click()
 
     def tearDown(self):
+        self.browser.driver.close()
         self.browser.quit()
 
     def test_displaying_question_and_answers(self):
@@ -672,6 +673,7 @@ class TestViewsFamiliaLive(StaticLiveServerTestCase):
     def tearDown(self):
         """ At the end of tests, close the browser.
         """
+        self.browser.driver.close()
         self.browser.quit()
 
     def test_edit_integrante_incomplete(self):
@@ -821,6 +823,7 @@ class TestViewsAdministracion(StaticLiveServerTestCase):
     def tearDown(self):
         """At the end of tests, close the browser.
         """
+        self.browser.driver.close()
         self.browser.quit()
 
     def test_capturista_dashboard_if_this_is_empty(self):

--- a/captura/tests.py
+++ b/captura/tests.py
@@ -42,6 +42,7 @@ class TestCapturaEstudio(StaticLiveServerTestCase):
         """ At the end of each test it closes the browser.
 
         """
+        self.browser.driver.close()
         self.browser.quit()
 
     def create_group(self, group_name):

--- a/captura/views.py
+++ b/captura/views.py
@@ -190,7 +190,6 @@ def capture_study(request, id_estudio, numero_seccion):
     context['data'] = data
     context['id_estudio'] = id_estudio
     context['seccion'] = seccion
-    context['status_options'] = Estudio.get_options_status()
 
     return render(request, 'captura/captura_estudio.html', context)
 

--- a/estudios_socioeconomicos/models.py
+++ b/estudios_socioeconomicos/models.py
@@ -28,9 +28,9 @@ class Estudio(models.Model):
         id for studies (refer to the sample study provided by the stakeholder).
     """
     APROBADO = 'aprobado'
-    RECHAZADO = 'rechazado'
-    BORRADOR = 'borrador'
-    REVISION = 'revision'
+    RECHAZADO = 'rechazado'  # rejected from the POV of the admin
+    BORRADOR = 'borrador'  # draft of a capturista
+    REVISION = 'revision'  # the admin has to check it
     ELIMINADO = 'eliminado'
     OPCIONES_STATUS = ((APROBADO, 'Aprobado'),
                        (RECHAZADO, 'Rechazado'),

--- a/jp2_online/templates/estudios_socioeconomicos/listado_estudios.html
+++ b/jp2_online/templates/estudios_socioeconomicos/listado_estudios.html
@@ -3,28 +3,21 @@
 
 {% block content %}
   <h2>Estudios Socioeconómicos</h2>
+  <p class="text-muted font-13 m-b-30">
+    {% if estado == status_options.REVISION %}
+      Pendientes
+    {% elif estado == status_options.RECHAZADO %}
+      Revisión            
+    {% elif estado == status_options.BORRADOR %}              
+      Borrador            
+    {% elif estado == status_options.APROBADO %}              
+      Aprobados            
+    {% elif estado == status_options.ELIMINADO %}
+      Eliminados
+    {% endif %}
+  </p>
+
   {% if estudios %}
-
-    <div class="row">
-      <div class="col-md-12">
-        <div class="content-box-header panel-heading">
-          <h2>
-            {% if estado == Estudio.REVISION %}
-                Estudios Socioeconómicos Pendientes
-            {% elif estado == Estudio.RECHAZADO %}
-                Estudios Socioeconómicos en revisión            
-            {% elif estado == Estudio.BORRADOR %}              
-                Estudios Socioeconómicos en borrador            
-            {% elif estado == Estudio.APROBADO %}              
-                Estudios Socioeconómicos aprobados            
-            {% elif estado == Estudio.ELIMINADO %}
-                Estudios Socioeconómicos eliminados
-            {% endif %}
-          </h2>
-        </div>
-      </div>
-    </div>
-
     <div class="row">       
       <div class="col-md-12 col-sm-12 col-xs-12">
         <div class="x_panel">
@@ -52,12 +45,16 @@
 
                       <td>{{estudio.familia.id}}</td>
                       <td>
-                        {% if estudio.status == 'revision' %}
+                        {% if estado == status_options.REVISION %}
                           Pendiente
-                        {% elif estudio.status == 'rechazado' %}
-                            En revisión
-                        {% else %}
-                          {{estudio.status}}
+                        {% elif estado == status_options.RECHAZADO %}
+                          En revisión            
+                        {% elif estado == status_options.BORRADOR %}              
+                          Borrador            
+                        {% elif estado == status_options.APROBADO %}              
+                          Aprobados           
+                        {% elif estado == status_options.ELIMINADO %}
+                          Eliminado
                         {% endif %}
                       </td>
                       <td>

--- a/jp2_online/templates/layouts/sidebar.html
+++ b/jp2_online/templates/layouts/sidebar.html
@@ -24,17 +24,18 @@
           <ul class="nav child_menu">
             <!--<li><a href="">Todos</a></li>-->
             <li>
-              <a href="{% url 'administracion:main_estudios' 'aprobado' %}">Aprobados
-              </a>
-            </li>
-            <li>
-              <a href="{% url 'administracion:main_estudios' 'pendientes' %}">
+              <a href="{% url 'administracion:main_estudios' 'revision' %}">
                 Pendientes
               </a>
             </li>
             <li>
-              <a href="{% url 'administracion:main_estudios' 'revision' %}">
-                En revisión
+              <a href="{% url 'administracion:main_estudios' 'aprobado' %}">
+                Aprobados
+              </a>
+            </li>
+            <li>
+              <a href="{% url 'administracion:main_estudios' 'rechazado' %}">
+                Rechazados
               </a>
             </li>
             <li>
@@ -44,7 +45,7 @@
             </li>
             <li>
               <a href="{% url 'administracion:main_estudios' 'borrador' %}">
-                En borrador
+                Borrador
               </a>
             </li>
         </ul>

--- a/tosp_auth/test_views.py
+++ b/tosp_auth/test_views.py
@@ -39,6 +39,7 @@ class TestAuthViews(StaticLiveServerTestCase):
         """At the end of tests, close the browser
 
         """
+        self.browser.driver.close()
         self.browser.quit()
 
     def test_empty_fields(self):

--- a/tosp_auth/tests.py
+++ b/tosp_auth/tests.py
@@ -70,6 +70,7 @@ class WidgetLogoutTest(StaticLiveServerTestCase):
     def tearDown(self):
         """At the end of tests, close the browser.
         """
+        self.browser.driver.close()
         self.browser.quit()
 
     def test_option_does_not_appear(self):


### PR DESCRIPTION
#### What's this PR do?
Fixes issues 72 and 71, changing tests accordingly.

Also, adds self.driver.close() call for all tests that use splinter. This is meant to be a [fix](https://github.com/SeleniumHQ/docker-selenium/issues/87#issuecomment-286231268) for the failing builds.

#### Where should the reviewer start?

jp2_online/templates/layouts/sidebar.html
jp2_online/templates/estudios_socioeconomicos/listado_estudios.html

#### How should this be manually tested?
run the tests

#### Any background context you want to provide?
Some of the views were also passing the dictionary with status to the template but was not being used. I removed those too.


This template was adapted ~stolen~ from [Quickleft/Sprint.ly](https://quickleft.com/blog/pull-request-templates-make-code-review-easier/)