### PR TITLE
Task/indicadores serializer

### DIFF
--- a/estudios_socioeconomicos/utils.py
+++ b/estudios_socioeconomicos/utils.py
@@ -24,6 +24,9 @@ def save_foreign_relationship(objects, serializer_class, model_class, foreign_in
         --------
         List of created and updated objects.
     """
+    if not objects:
+        return
+
     updated_objects = []
 
     for obj in objects:

--- a/familias/serializers.py
+++ b/familias/serializers.py
@@ -246,9 +246,9 @@ class FamiliaSerializer(serializers.ModelSerializer):
             the family that depend upon the creation of a family
             instance first. This are the Integrantes and Comentarios.
 
-            We first remove all Integrante and comentario from the
-            validated data. We create the family and then we create
-            this objects that require the family instance.
+            We first remove all Integrante, Comentario and Transaccion
+            from the validated data. We create the family and then we
+            create this objects that require the family instance.
         """
         integrantes = self.validated_data.pop('integrante_familia')
         comentarios = self.validated_data.pop('comentario_familia')
@@ -282,8 +282,8 @@ class FamiliaSerializer(serializers.ModelSerializer):
             looks for the id in the object. If there is no data it will
             create the object.
 
-            Integrantes has a non-destructive way of disactivating. This
-            is donde by changin the is_active field.
+            Integrantes and Transacciones has a non-destructive way of disactivating.
+            This is donde by changing the is_active field.
 
             Comentario does not have this field, so all comentario instances
             that were not sent by the offline application most be removed.

--- a/familias/serializers.py
+++ b/familias/serializers.py
@@ -110,6 +110,9 @@ class TutorSerializer(serializers.ModelSerializer):
             nested created objects, the integrante must be
             created first and passed as parameter to the
             created function.
+
+            After creating the tutor object we use save_foreign_relationship
+            to save ingreso objects that depend on tutor.
         """
         ingresos = self.validated_data.pop('tutor_ingresos', None)
 

--- a/indicadores/models.py
+++ b/indicadores/models.py
@@ -88,7 +88,7 @@ class Transaccion(models.Model):
         This field indicates whether a certain transaction is an income
         or an expense.
     """
-    familia = models.ForeignKey(Familia)
+    familia = models.ForeignKey(Familia, related_name='transacciones')
     activo = models.BooleanField(default=True)
     monto = models.DecimalField(max_digits=12, decimal_places=2)
     periodicidad = models.ForeignKey(Periodo)

--- a/indicadores/models.py
+++ b/indicadores/models.py
@@ -157,7 +157,7 @@ class Ingreso(models.Model):
     transaccion = models.OneToOneField(Transaccion)
     fecha = models.DateField()
     tipo = models.TextField(choices=OPCIONES_TIPO)
-    tutor = models.ForeignKey(Tutor, null=True)
+    tutor = models.ForeignKey(Tutor, null=True, related_name='tutor_ingresos')
 
     def __str__(self):
         """ This function returns the __str__ method of the parent transaction.

--- a/indicadores/serializers.py
+++ b/indicadores/serializers.py
@@ -3,7 +3,9 @@ from .models import Oficio, Periodo, Transaccion, Ingreso
 
 
 class OficioSerializer(serializers.ModelSerializer):
-    """
+    """ Serializer to represent a .models.Oficio instance
+        through a REST endpoint for the offline application
+        to submit information.
     """
     class Meta:
         model = Oficio
@@ -11,7 +13,9 @@ class OficioSerializer(serializers.ModelSerializer):
 
 
 class PeriodoSerializer(serializers.ModelSerializer):
-    """
+    """ Serializer to represent a .models.Periodo instance
+        through a REST endpoint for the offline application
+        to submit information.
     """
     class Meta:
         model = Periodo
@@ -21,7 +25,11 @@ class PeriodoSerializer(serializers.ModelSerializer):
 
 
 class TransaccionSerializer(serializers.ModelSerializer):
-    """
+    """ Serializer to represent a .models.Transaccion instance
+        through a REST endpoint for the offline application
+        to submit information.
+
+        @TODO: Implement creating Ingreso from Transaccion
     """
     periodicidad = PeriodoSerializer()
 
@@ -38,7 +46,17 @@ class TransaccionSerializer(serializers.ModelSerializer):
         extra_kwargs = {'id': {'read_only': False, 'required': False}}
 
     def create(self, familia):
-        """
+        """ This function overides the default behaviour for creating
+            an object through a serializer.
+
+            This serializer dependes on a .models.Familia
+            object instance. Since we are dealing with
+            nested created objects, the familia must be
+            created first and passed as parameter to the
+            created function.
+
+            Finally a Periodo object os created from the data passed
+            throught the serializer.
         """
         periodicidad = self.validated_data.pop('periodicidad')
         periodo = Periodo.objects.create(**periodicidad)
@@ -48,7 +66,10 @@ class TransaccionSerializer(serializers.ModelSerializer):
         return Transaccion.objects.create(**self.validated_data)
 
     def update(self):
-        """
+        """ This function overides the default behaviour for creating
+            an object through a serializer.
+
+            Updates a Transaccion object and the periodicidad nested object.
         """
         periodicidad = self.validated_data.pop('periodicidad')
         Periodo.objects.filter(pk=periodicidad['id']).update(**periodicidad)
@@ -60,7 +81,9 @@ class TransaccionSerializer(serializers.ModelSerializer):
 
 
 class IngresoSerializer(serializers.ModelSerializer):
-    """
+    """ Serializer to represent a .models.Ingreso instance
+        through a REST endpoint for the offline application
+        to submit information.
     """
     transaccion = TransaccionSerializer()
 
@@ -74,6 +97,6 @@ class IngresoSerializer(serializers.ModelSerializer):
             'tutor')
 
     def create(self, tutor):
-        """
+        """ @TODO: This serializer is created through a Transaccion object.
         """
         return IngresoSerializer.objects.create(**self.validated_data)

--- a/indicadores/serializers.py
+++ b/indicadores/serializers.py
@@ -1,0 +1,79 @@
+from rest_framework import serializers
+from .models import Oficio, Periodo, Transaccion, Ingreso
+
+
+class OficioSerializer(serializers.ModelSerializer):
+    """
+    """
+    class Meta:
+        model = Oficio
+        fields = ('id', 'nombre')
+
+
+class PeriodoSerializer(serializers.ModelSerializer):
+    """
+    """
+    class Meta:
+        model = Periodo
+        fields = ('id', 'periodicidad', 'factor', 'multiplica')
+
+        extra_kwargs = {'id': {'read_only': False, 'required': False}}
+
+
+class TransaccionSerializer(serializers.ModelSerializer):
+    """
+    """
+    periodicidad = PeriodoSerializer()
+
+    class Meta:
+        model = Transaccion
+        fields = (
+            'id',
+            'activo',
+            'monto',
+            'periodicidad',
+            'observacion',
+            'es_ingreso')
+
+        extra_kwargs = {'id': {'read_only': False, 'required': False}}
+
+    def create(self, familia):
+        """
+        """
+        periodicidad = self.validated_data.pop('periodicidad')
+        periodo = Periodo.objects.create(**periodicidad)
+        self.validated_data['periodicidad'] = periodo
+        self.validated_data['familia'] = familia
+
+        return Transaccion.objects.create(**self.validated_data)
+
+    def update(self):
+        """
+        """
+        periodicidad = self.validated_data.pop('periodicidad')
+        Periodo.objects.filter(pk=periodicidad['id']).update(**periodicidad)
+        periodo = Periodo.objects.get(pk=periodicidad['id'])
+        self.validated_data['periodicidad'] = periodo
+
+        Transaccion.objects.filter(pk=self.instance.pk).update(**self.validated_data)
+        return Periodo.objects.get(pk=self.instance.pk)
+
+
+class IngresoSerializer(serializers.ModelSerializer):
+    """
+    """
+    transaccion = TransaccionSerializer()
+
+    class Meta:
+        model = Ingreso
+        fields = (
+            'id',
+            'transaccion',
+            'fecha',
+            'tipo',
+            'tutor')
+
+    def create(self, tutor):
+        """
+        """
+        return IngresoSerializer.objects.create(**self.validated_data)

--- a/indicadores/serializers.py
+++ b/indicadores/serializers.py
@@ -1,4 +1,7 @@
 from rest_framework import serializers
+
+from estudios_socioeconomicos.utils import save_foreign_relationship
+
 from .models import Oficio, Periodo, Transaccion, Ingreso
 
 
@@ -23,13 +26,24 @@ class PeriodoSerializer(serializers.ModelSerializer):
 
         extra_kwargs = {'id': {'read_only': False, 'required': False}}
 
+    def create(self):
+        """ This function overides the default behaviour for creating
+            an object through a serializer.
+        """
+        return Periodo.objects.create(**self.validated_data)
+
+    def update(self):
+        """ This function overides the default behaviour for updating
+            an object through a serializer.
+        """
+        Periodo.objects.filter(pk=self.instance.pk).update(**self.validated_data)
+        return Periodo.objects.get(pk=self.instance.pk)
+
 
 class TransaccionSerializer(serializers.ModelSerializer):
     """ Serializer to represent a .models.Transaccion instance
         through a REST endpoint for the offline application
         to submit information.
-
-        @TODO: Implement creating Ingreso from Transaccion
     """
     periodicidad = PeriodoSerializer()
 
@@ -49,17 +63,26 @@ class TransaccionSerializer(serializers.ModelSerializer):
         """ This function overides the default behaviour for creating
             an object through a serializer.
 
+            This serializer can be called from a familia create method.
+            If we are dealing with familia Transactions of from a Tutor
+            create method if we are dealing with Tutor Transactions.
+
             This serializer dependes on a .models.Familia
             object instance. Since we are dealing with
             nested created objects, the familia must be
             created first and passed as parameter to the
             created function.
 
-            Finally a Periodo object os created from the data passed
+            Finally a Periodo object is created from the data passed
             throught the serializer.
         """
         periodicidad = self.validated_data.pop('periodicidad')
-        periodo = Periodo.objects.create(**periodicidad)
+
+        periodo = save_foreign_relationship(
+            [periodicidad],
+            PeriodoSerializer,
+            Periodo)[0]
+
         self.validated_data['periodicidad'] = periodo
         self.validated_data['familia'] = familia
 
@@ -72,12 +95,14 @@ class TransaccionSerializer(serializers.ModelSerializer):
             Updates a Transaccion object and the periodicidad nested object.
         """
         periodicidad = self.validated_data.pop('periodicidad')
-        Periodo.objects.filter(pk=periodicidad['id']).update(**periodicidad)
-        periodo = Periodo.objects.get(pk=periodicidad['id'])
-        self.validated_data['periodicidad'] = periodo
+
+        save_foreign_relationship(
+            [periodicidad],
+            PeriodoSerializer,
+            Periodo)[0]
 
         Transaccion.objects.filter(pk=self.instance.pk).update(**self.validated_data)
-        return Periodo.objects.get(pk=self.instance.pk)
+        return Transaccion.objects.get(pk=self.instance.pk)
 
 
 class IngresoSerializer(serializers.ModelSerializer):
@@ -91,12 +116,45 @@ class IngresoSerializer(serializers.ModelSerializer):
         model = Ingreso
         fields = (
             'id',
-            'transaccion',
             'fecha',
             'tipo',
-            'tutor')
+            'transaccion')
+
+        extra_kwargs = {'id': {'read_only': False, 'required': False}}
 
     def create(self, tutor):
-        """ @TODO: This serializer is created through a Transaccion object.
+        """ This function overides the default behaviour for creating
+            an object through a serializer.
+
+            This object depends on a nested relation with transaccion
+            therefore it creates the object before saving.
         """
-        return IngresoSerializer.objects.create(**self.validated_data)
+
+        transaccion = self.validated_data.pop('transaccion')
+        transaccion_instance = save_foreign_relationship(
+            [transaccion],
+            TransaccionSerializer,
+            Transaccion,
+            tutor.integrante.familia)
+
+        self.validated_data['transaccion'] = transaccion_instance[0]
+        self.validated_data['tutor'] = tutor
+        return Ingreso.objects.create(**self.validated_data)
+
+    def update(self):
+        """ This function overides the default behaviour for updating
+            an object through a serializer.
+
+            Updates nested relashionship with transaccion and then updates
+            local information.
+        """
+
+        transaccion = self.validated_data.pop('transaccion')
+        save_foreign_relationship(
+            [transaccion],
+            TransaccionSerializer,
+            Transaccion,
+            self.instance.tutor.integrante.familia)
+
+        Ingreso.objects.filter(pk=self.instance.pk).update(**self.validated_data)
+        return Ingreso.objects.get(pk=self.instance.pk)

--- a/jp2_online/templates/administracion/crud_users.html
+++ b/jp2_online/templates/administracion/crud_users.html
@@ -167,6 +167,7 @@
     }
   });
   function openEditModal(num){
+    // console.log("SASTRES")
     window.console.log(num)
      // $("#test").submit(function(event){
             $.ajax({

--- a/jp2_online/templates/administracion/crud_users.html
+++ b/jp2_online/templates/administracion/crud_users.html
@@ -167,7 +167,6 @@
     }
   });
   function openEditModal(num){
-    // console.log("SASTRES")
     window.console.log(num)
      // $("#test").submit(function(event){
             $.ajax({


### PR DESCRIPTION
#### What's this PR do?

Adds the serializers and functionality for offline client to submit transactions and indicadores.

#### Where should the reviewer start?

indicadores/serializers.py
familia/serializers.py
captura/test_api_views.py

#### How should this be manually tested?

python manage.py test captura

#### Any background context you want to provide?

The relashionsip with transactions is a bit tricky. Transactions can be added through a relashionship with familia. But integrantes can also have transactions that come from ingresos. So if the API want to add normal transactions they can add them for the familia information. If they want to add an ingreso a a family member they add it in that section.

This template was adapted ~stolen~ from [Quickleft/Sprint.ly](https://quickleft.com/blog/pull-request-templates-make-code-review-easier/)