### PR TITLE
Task/recover delete studies admin

### DIFF
--- a/administracion/test_views.py
+++ b/administracion/test_views.py
@@ -358,7 +358,7 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
         self.assertFalse(self.browser.is_text_present('Número'))
         self.assertFalse(self.browser.is_text_present('Id Familia'))
         # self.assertFalse(self.browser.is_text_present('Nombre del Capturista'))
-        self.assertFalse(self.browser.is_text_present('Ver'))
+        self.assertFalse(self.browser.is_text_present('Acciones'))
 
     def test_studies_rejected_appears_for_user_admin(self):
         """ Test for url 'administracion:main_estudios' with the 'rechazado' argument.
@@ -406,7 +406,7 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
         self.assertTrue(self.browser.is_text_present('Número'))
         self.assertTrue(self.browser.is_text_present('Familia'))
         self.assertTrue(self.browser.is_text_present('Nombre del Capturista'))
-        self.assertTrue(self.browser.is_text_present('Ver'))
+        self.assertTrue(self.browser.is_text_present('Acciones'))
         self.assertTrue(self.browser.is_text_present('Rechazado'))
 
     def test_if_not_exist_any_studies_as_pending(self):
@@ -431,7 +431,7 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
         self.assertFalse(self.browser.is_text_present('Número'))
         self.assertFalse(self.browser.is_text_present('Familia'))
         self.assertFalse(self.browser.is_text_present('Nombre del Capturista'))
-        self.assertFalse(self.browser.is_text_present('Ver'))
+        self.assertFalse(self.browser.is_text_present('Acciones'))
 
     def test_studies_as_pending_appears_for_admin(self):
         """ Test for url 'administracion:main_estudios' with the 'revision' parameter.
@@ -479,7 +479,7 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
         self.assertTrue(self.browser.is_text_present('Número'))
         self.assertTrue(self.browser.is_text_present('Familia'))
         self.assertTrue(self.browser.is_text_present('Nombre del Capturista'))
-        self.assertTrue(self.browser.is_text_present('Ver'))
+        self.assertTrue(self.browser.is_text_present('Acciones'))
         self.assertTrue(self.browser.is_text_present('Pendiente'))
 
     def test_if_not_exist_any_studies_approved(self):
@@ -504,7 +504,7 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
         self.assertFalse(self.browser.is_text_present('Número'))
         self.assertFalse(self.browser.is_text_present('Familia'))
         self.assertFalse(self.browser.is_text_present('Nombre del Capturista'))
-        self.assertFalse(self.browser.is_text_present('Ver'))
+        self.assertFalse(self.browser.is_text_present('Acciones'))
 
     def test_studies_approved_appears_for_admin(self):
         """ Test for url 'administracion:main_estudios' with the 'aprobado' parameter.
@@ -553,7 +553,7 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
         self.assertTrue(self.browser.is_text_present('Número'))
         self.assertTrue(self.browser.is_text_present('Familia'))
         self.assertTrue(self.browser.is_text_present('Nombre del Capturista'))
-        self.assertTrue(self.browser.is_text_present('Ver'))
+        self.assertTrue(self.browser.is_text_present('Acciones'))
         self.assertTrue(self.browser.is_text_present('Aprobado'))
 
     def test_if_not_exist_any_draft_studies(self):
@@ -578,7 +578,7 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
         self.assertFalse(self.browser.is_text_present('Número'))
         self.assertFalse(self.browser.is_text_present('Familia'))
         self.assertFalse(self.browser.is_text_present('Nombre del Capturista'))
-        self.assertFalse(self.browser.is_text_present('Ver'))
+        self.assertFalse(self.browser.is_text_present('Acciones'))
 
     def test_draft_studies_appears_for_admin(self):
         """ Test for url 'administracion:main_estudios' with the 'borrador' parameter.
@@ -626,7 +626,7 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
         self.assertTrue(self.browser.is_text_present('Número'))
         self.assertTrue(self.browser.is_text_present('Familia'))
         self.assertTrue(self.browser.is_text_present('Nombre del Capturista'))
-        self.assertTrue(self.browser.is_text_present('Ver'))
+        self.assertTrue(self.browser.is_text_present('Acciones'))
         self.assertTrue(self.browser.is_text_present('Borrador'))
 
     def test_if_not_exist_any_studies_deleted(self):
@@ -651,7 +651,7 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
         self.assertFalse(self.browser.is_text_present('Número'))
         self.assertFalse(self.browser.is_text_present('Familia'))
         self.assertFalse(self.browser.is_text_present('Nombre del Capturista'))
-        self.assertFalse(self.browser.is_text_present('Ver'))
+        self.assertFalse(self.browser.is_text_present('Acciones'))
 
     def test_studies_deleted_appears_for_admin(self):
         """ Test for url 'administracion:main_estudios' with the 'eliminado_admin' parameter.
@@ -701,5 +701,5 @@ class StudiesDashboardAdministratorTest(StaticLiveServerTestCase):
         self.assertTrue(self.browser.is_text_present('Número'))
         self.assertTrue(self.browser.is_text_present('Familia'))
         self.assertTrue(self.browser.is_text_present('Nombre del Capturista'))
-        self.assertTrue(self.browser.is_text_present('Ver'))
+        self.assertTrue(self.browser.is_text_present('Acciones'))
         self.assertTrue(self.browser.is_text_present('Eliminado'))

--- a/captura/views.py
+++ b/captura/views.py
@@ -8,9 +8,10 @@ from rest_framework import generics, permissions, status, viewsets
 from rest_framework.response import Response
 
 from administracion.models import Escuela
-from perfiles_usuario.utils import is_capturista
+from perfiles_usuario.utils import CAPTURISTA_GROUP, ADMINISTRADOR_GROUP, is_member, \
+                                   is_capturista
 from perfiles_usuario.models import Capturista
-from estudios_socioeconomicos.forms import DeleteEstudioCapturistaForm, RespuestaForm, \
+from estudios_socioeconomicos.forms import DeleteEstudioForm, RespuestaForm, \
                                            RecoverEstudioForm
 from estudios_socioeconomicos.serializers import SeccionSerializer, EstudioSerializer
 from estudios_socioeconomicos.serializers import FotoSerializer
@@ -263,7 +264,7 @@ def create_estudio(request):
 
 
 @login_required
-@user_passes_test(is_capturista)
+@user_passes_test(lambda u: is_member(u, [ADMINISTRADOR_GROUP, CAPTURISTA_GROUP]))
 def estudio_delete_modal(request, id_estudio):
     """ View to send the form to delete users.
 
@@ -282,22 +283,22 @@ def estudio_delete_modal(request, id_estudio):
     """
     if request.is_ajax():
         estudio = get_object_or_404(Estudio, pk=id_estudio)
-        form = DeleteEstudioCapturistaForm(initial={'id_estudio': estudio.pk})
+        form = DeleteEstudioForm(initial={'id_estudio': estudio.pk})
         return render(request, 'estudios_socioeconomicos/estudio_delete_modal.html',
                       {'estudio_to_delete': estudio, 'delete_form': form})
     return HttpResponseBadRequest()
 
 
 @login_required
-@user_passes_test(is_capturista)
+@user_passes_test(lambda u: is_member(u, [ADMINISTRADOR_GROUP, CAPTURISTA_GROUP]))
 def estudio_delete(request):
     """ View to delete estudio.
 
     """
     if request.method == 'POST':
-        form = DeleteEstudioCapturistaForm(request.POST)
+        form = DeleteEstudioForm(request.POST)
         if form.is_valid():
-            form.save()
+            form.save(user_id=request.user.pk)
         return redirect('captura:estudios')
     return HttpResponseBadRequest()
 

--- a/captura/views.py
+++ b/captura/views.py
@@ -318,7 +318,7 @@ def recover_estudios(request):
 
 
 @login_required
-@user_passes_test(is_capturista)
+@user_passes_test(lambda u: is_member(u, [ADMINISTRADOR_GROUP, CAPTURISTA_GROUP]))
 def estudio_recover_modal(request, id_estudio):
     """ View that is called via ajax to render the modal
     to confirm the recovery of a study.
@@ -336,7 +336,7 @@ def estudio_recover_modal(request, id_estudio):
 
 
 @login_required
-@user_passes_test(is_capturista)
+@user_passes_test(lambda u: is_member(u, [ADMINISTRADOR_GROUP, CAPTURISTA_GROUP]))
 def estudio_recover(request):
     """ This view receives the form to recover a study
     and redirects to the listing of deleted studies.

--- a/estudios_socioeconomicos/test_forms.py
+++ b/estudios_socioeconomicos/test_forms.py
@@ -83,7 +83,7 @@ class RecoverDeleteFormsTest(TestCase):
         form_data = {'id_estudio': self.estudio1.id}
         form = DeleteEstudioForm(data=form_data)
         self.assertTrue(form.is_valid())
-        form.save(user_id=self.capturista.pk)
+        form.save(user_id=self.capturista.user.pk)
         estudio = Estudio.objects.get(pk=self.estudio1.pk)
         self.assertEqual(estudio.status, Estudio.ELIMINADO_CAPTURISTA)
         integrante = Integrante.objects.get(pk=self.integrante1.pk)

--- a/estudios_socioeconomicos/test_forms.py
+++ b/estudios_socioeconomicos/test_forms.py
@@ -1,10 +1,11 @@
 from django.test import TestCase
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group
 from django.forms import ValidationError
 from familias.models import Familia, Integrante, Alumno
 from administracion.models import Escuela
 from perfiles_usuario.models import Capturista
-from .forms import DeleteEstudioCapturistaForm, RecoverEstudioForm
+from perfiles_usuario.utils import ADMINISTRADOR_GROUP
+from .forms import DeleteEstudioForm, RecoverEstudioForm
 from .models import Estudio
 
 
@@ -35,9 +36,9 @@ class RecoverDeleteFormsTest(TestCase):
 
     def setUp(self):
         """ This sets up the database with the necessary values for the testing of the
-        DeleteEstudioCapturistaForm
+        DeleteEstudioForm
         """
-        elerik = User.objects.create_user(
+        self.elerik = User.objects.create_user(
             username='erikiano',
             email='latelma@junipero.sas',
             password='vacalalo',
@@ -46,7 +47,7 @@ class RecoverDeleteFormsTest(TestCase):
 
         self.escuela = Escuela.objects.create(nombre='Juan Pablo')
 
-        self.capturista = Capturista.objects.create(user=elerik)
+        self.capturista = Capturista.objects.create(user=self.elerik)
 
         numero_hijos_inicial = 3
         estado_civil_inicial = 'soltero'
@@ -74,16 +75,39 @@ class RecoverDeleteFormsTest(TestCase):
                                              numero_sae='5876',
                                              escuela=self.escuela)
 
-    def test_form_soft_deletes(self):
+    def test_delete_estudio_capturista(self):
         """ This tests that the save method of the form, changes the status
         of the estudio, as well as the activo value of all related 'people'.
+        The user deleting in this case is a capturista.
         """
         form_data = {'id_estudio': self.estudio1.id}
-        form = DeleteEstudioCapturistaForm(data=form_data)
+        form = DeleteEstudioForm(data=form_data)
         self.assertTrue(form.is_valid())
-        form.save()
+        form.save(user_id=self.capturista.pk)
         estudio = Estudio.objects.get(pk=self.estudio1.pk)
         self.assertEqual(estudio.status, Estudio.ELIMINADO_CAPTURISTA)
+        integrante = Integrante.objects.get(pk=self.integrante1.pk)
+        self.assertEqual(integrante.activo, False)
+        integrante = Integrante.objects.get(pk=self.integrante2.pk)
+        self.assertEqual(integrante.activo, False)
+        alumno = Alumno.objects.get(pk=self.alumno1.pk)
+        self.assertEqual(alumno.activo, False)
+
+    def test_delete_estudio_admin(self):
+        """ This tests that the save method of the form, changes the status
+        of the estudio, as well as the activo value of all related 'people'.
+        The user deleting in this case is an administrative.
+        """
+        administrators = Group.objects.get_or_create(name=ADMINISTRADOR_GROUP)[0]
+        administrators.user_set.add(self.elerik)
+        administrators.save()
+
+        form_data = {'id_estudio': self.estudio1.id}
+        form = DeleteEstudioForm(data=form_data)
+        self.assertTrue(form.is_valid())
+        form.save(user_id=self.capturista.user.pk)
+        estudio = Estudio.objects.get(pk=self.estudio1.pk)
+        self.assertEqual(estudio.status, Estudio.ELIMINADO_ADMIN)
         integrante = Integrante.objects.get(pk=self.integrante1.pk)
         self.assertEqual(integrante.activo, False)
         integrante = Integrante.objects.get(pk=self.integrante2.pk)

--- a/jp2_online/templates/estudios_socioeconomicos/listado_estudios.html
+++ b/jp2_online/templates/estudios_socioeconomicos/listado_estudios.html
@@ -55,6 +55,10 @@
                           <a id="delete_estudio_{{ estudio.id }}" class="delete_estudio_link mouseClick btn btn-danger" data-form="{% url 'captura:estudio_delete_modal' estudio.id %}">
                             <i class="glyphicon glyphicon-trash"></i> Borrar
                           </a>
+                        {% elif estudio.status == status_options.ELIMINADO_ADMIN %}
+                          <a id="recover_estudio_{{ estudio.id }}" class="recover_estudio_link mouseClick btn btn-success" data-form="{% url 'captura:estudio_recover_modal' estudio.pk %}">
+                            <i class="glyphicon glyphicon-plus"></i> Recuperar
+                          </a>
                         {% endif %}
                       </td>
                     </tr>
@@ -85,6 +89,16 @@
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
+
+<div class="modal fade" tabindex="-1" role="dialog" id="modal_recover_estudio">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content" id="modal_recover_estudio_content">
+      
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+
+
 {% endblock %}
 
 {% block extra_page_js %}
@@ -119,12 +133,21 @@
     });
 
   $(".delete_estudio_link").click(function(ev) { // for each edit contact url
-      ev.preventDefault(); // prevent navigation
-      var url = $(this).data("form"); // get the contact form url
-      $("#modal_delete_estudio_content").load(url, function() { // load the url into the modal
-          $("#modal_delete_estudio").modal('show'); // display the modal on url load
-      });
-      return false; // prevent the click propagation
+    ev.preventDefault(); // prevent navigation
+    var url = $(this).data("form"); // get the contact form url
+    $("#modal_delete_estudio_content").load(url, function() { // load the url into the modal
+      $("#modal_delete_estudio").modal('show'); // display the modal on url load
+    });
+    return false; // prevent the click propagation
+  });
+
+  $('.recover_estudio_link').click(function(ev) {
+    ev.preventDefault(); // prevent navigation
+    var url = $(this).data('form'); // get the contact form url
+    $('#modal_recover_estudio_content').load(url, function() { // load the url into the modal
+      $('#modal_recover_estudio').modal('show'); // display the modal on url load
+    });
+    return false; // prevent the click propagation
   });
 
   </script>

--- a/jp2_online/templates/estudios_socioeconomicos/listado_estudios.html
+++ b/jp2_online/templates/estudios_socioeconomicos/listado_estudios.html
@@ -29,7 +29,7 @@
                   <th>Nombre del Capturista</th>
                   <th>Familia</th>
                   <th>Estado del estudio</th>
-                  <th>Ver</th>
+                  <th>Acciones</th>
                 </tr>
               </thead>
 
@@ -51,6 +51,11 @@
                         <a class="btn btn-success btn-circle-sm" href="#">
                           <span class="glyphicon glyphicon-circle-arrow-right"></span>
                         </a>
+                        {% if estudio.status == status_options.APROBADO %} 
+                          <a id="delete_estudio_{{ estudio.id }}" class="delete_estudio_link mouseClick btn btn-danger" data-form="{% url 'captura:estudio_delete_modal' estudio.id %}">
+                            <i class="glyphicon glyphicon-trash"></i> Borrar
+                          </a>
+                        {% endif %}
                       </td>
                     </tr>
                 {% endfor %}
@@ -72,4 +77,55 @@
       </div>
     </div>
   {% endif%}
+
+<div class="modal fade" tabindex="-1" role="dialog" id="modal_delete_estudio">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content" id="modal_delete_estudio_content">
+      
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+{% endblock %}
+
+{% block extra_page_js %}
+  <script type="text/javascript">
+    // using jQuery
+    function csrfSafeMethod(method) {
+      // these HTTP methods do not require CSRF protection
+      return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+    }
+    function getCookie(name) {
+      var cookieValue = null;
+      if (document.cookie && document.cookie !== '') {
+          var cookies = document.cookie.split(';');
+          for (var i = 0; i < cookies.length; i++) {
+              var cookie = jQuery.trim(cookies[i]);
+              // Does this cookie string begin with the name we want?
+              if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                  cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                  break;
+              }
+          }
+      }
+      return cookieValue;
+    }
+    var csrftoken = getCookie('csrftoken');
+    $.ajaxSetup({
+      beforeSend: function(xhr, settings) {
+          if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+              xhr.setRequestHeader("X-CSRFToken", csrftoken);
+          }
+      }
+    });
+
+  $(".delete_estudio_link").click(function(ev) { // for each edit contact url
+      ev.preventDefault(); // prevent navigation
+      var url = $(this).data("form"); // get the contact form url
+      $("#modal_delete_estudio_content").load(url, function() { // load the url into the modal
+          $("#modal_delete_estudio").modal('show'); // display the modal on url load
+      });
+      return false; // prevent the click propagation
+  });
+
+  </script>
 {% endblock %}


### PR DESCRIPTION
#### What's this PR do?
Adds the functionality to recover and delete studies for the admin. (i messed up the branch name hehe)

#### Where should the reviewer start?
The main thing to note is that we are reusing the views used to delete and recover studies for the capturista. Thus, we only add a bit of logic in the save method of the delete form (the logic was already implemented in the recover on the last pr).

estudios_socioeconomicos/forms.py
captura/views.py (note the decorators)
static files

#### How should this be manually tested?
try deleting and recovering studies with an admin. The option to delete only appears for approved studies, and the option to recover on deleted ones.

#### Any background context you want to provide?



This template was adapted ~stolen~ from [Quickleft/Sprint.ly](https://quickleft.com/blog/pull-request-templates-make-code-review-easier/)