### PR TITLE
Add the preeschool options to the integrante form

### DIFF
--- a/familias/models.py
+++ b/familias/models.py
@@ -189,7 +189,13 @@ class Integrante(models.Model):
     OPCION_ESTUDIOS_UNIVERSIDAD = 'universidad'
     OPCION_ESTUDIOS_MAESTRIA = 'maestria'
     OPCION_ESTUDIOS_DOCTORADO = 'doctorado'
+    OPCION_ESTUDIOS_PREESCOLAR_1 = 'kinder_1'
+    OPCION_ESTUDIOS_PREESCOLAR_2 = 'kinder_2'
+    OPCION_ESTUDIOS_PREESCOLAR_3 = 'kinder_3'
     OPCIONES_NIVEL_ESTUDIOS = ((OPCION_ESTUDIOS_NINGUNO, 'Ninguno'),
+                               (OPCION_ESTUDIOS_PREESCOLAR_1, 'Primero de Preescolar'),
+                               (OPCION_ESTUDIOS_PREESCOLAR_2, 'Segundo de Preescolar'),
+                               (OPCION_ESTUDIOS_PREESCOLAR_3, 'Tercero de Preescolar'),
                                (OPCION_ESTUDIOS_1, 'Primero de Primaria'),
                                (OPCION_ESTUDIOS_2, 'Segundo de Primaria'),
                                (OPCION_ESTUDIOS_3, 'Tercero de Primaria'),

--- a/familias/test_models.py
+++ b/familias/test_models.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from .models import Familia, Oficio
+from .models import Familia, Integrante, Oficio
 
 
 class TestFamiliaModel(TestCase):
@@ -42,3 +42,46 @@ class TestOficio(TestCase):
         """
         oficio = Oficio.objects.get(nombre=self.nombre)
         self.assertEqual(str(oficio), self.nombre)
+
+
+class TestIntegranteModel(TestCase):
+    """ Unit test suite for testing the Integrante moden in .models
+
+    Attributes:
+    -----------
+    familia : Familia
+        The family to which new members will be linked.
+    integrante : Integrante
+        Integrante created as a subject for the tests.
+    """
+
+    def setUp(self):
+        """ Setup required for the tests in this suite.
+
+        """
+        self.familia = Familia.objects.create(nombre_familiar='Molina',
+                                              numero_hijos_diferentes_papas=2,
+                                              estado_civil='soltero',
+                                              localidad='Nabo')
+        self.integrante = Integrante.objects.create(familia=self.familia,
+                                                    nombres='Rick',
+                                                    apellidos='Astley',
+                                                    nivel_estudios='doctorado',
+                                                    fecha_de_nacimiento='1996-02-26')
+
+    def test_str(self):
+        """ Test for the integrante __str__ method.
+
+        This tests that it returns the full name of the integrante.
+        """
+        self.assertEqual(str(self.integrante), 'Rick Astley')
+
+    def test_kindergarten_option(self):
+        """ Test that kindergarten is an option for scholarity
+
+        The new tests refer to the ability to have kindergarten as an
+        option for the scholarity level of a family member
+        """
+        self.assertTrue(Integrante.OPCION_ESTUDIOS_PREESCOLAR_1)
+        self.assertTrue(Integrante.OPCION_ESTUDIOS_PREESCOLAR_2)
+        self.assertTrue(Integrante.OPCION_ESTUDIOS_PREESCOLAR_3)


### PR DESCRIPTION
The option to add preeschool scholarity grades in the integrante form
has been added, as per request by stakeholders.

#### What's this PR do?
Add the three preschool grades as option when a new integrante is being edited or created

#### Where should the reviewer start?
The reviewer should check familias/models.py frist, and then the tests.

#### How should this be manually tested?
Login as a capturista, create a new study, and check that preeschool appears as an scholarity option for integrantes.

#### Any background context you want to provide?
This change was requested by stakeholders.


This template was adapted ~stolen~ from [Quickleft/Sprint.ly](https://quickleft.com/blog/pull-request-templates-make-code-review-easier/)