### PR TITLE
Add the option to the database to select student as a possible ocupat…

### DIFF
--- a/familias/migrations/0034_add_oficio_estudiante.py
+++ b/familias/migrations/0034_add_oficio_estudiante.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+def forwards_func(apps, schema_editor):
+    # We get the model from the versioned app registry;
+    # if we directly import it, it'll be the wrong version
+    Oficio = apps.get_model('familias', 'Oficio')
+    db_alias = schema_editor.connection.alias
+    Oficio.objects.using(db_alias).bulk_create([
+        Oficio(nombre='Estudiante'),
+    ])
+
+def reverse_func(apps, schema_editor):
+    # forwards_func() creates two Country instances,
+    # so reverse_func() should delete them.
+    Oficio = apps.get_model('familias', 'Oficio')
+    db_alias = schema_editor.connection.alias
+    Oficio.objects.using(db_alias).filter(nombre='Estudiante').delete()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('familias', '0033_auto_20170429_2310'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, reverse_func),
+    ]

--- a/familias/test_migrations.py
+++ b/familias/test_migrations.py
@@ -1,0 +1,35 @@
+from django.test import TestCase
+from .models import Oficio
+
+
+class TestLoadOficios(TestCase):
+    """ Unit test suite for testing that initial data of
+    periodos is created
+    """
+
+    def test_oficios_created(self):
+        """ Checks that all the original oficios where loaded correctly.
+        """
+        self.assertTrue(Oficio.objects.get(nombre='Empleado'))
+        self.assertTrue(Oficio.objects.get(nombre='Obrero'))
+        self.assertTrue(Oficio.objects.get(nombre='Jefe de línea'))
+        self.assertTrue(Oficio.objects.get(nombre='Área de limpieza'))
+        self.assertTrue(Oficio.objects.get(nombre='Administrativo'))
+        self.assertTrue(Oficio.objects.get(nombre='Empleada doméstica'))
+        self.assertTrue(Oficio.objects.get(nombre='Jardinero'))
+        self.assertTrue(Oficio.objects.get(nombre='Plomero'))
+        self.assertTrue(Oficio.objects.get(nombre='Herrero'))
+        self.assertTrue(Oficio.objects.get(nombre='Carpintero'))
+        self.assertTrue(Oficio.objects.get(nombre='Albañil'))
+        self.assertTrue(Oficio.objects.get(nombre='Pintor'))
+        self.assertTrue(Oficio.objects.get(nombre='Mesero'))
+        self.assertTrue(Oficio.objects.get(nombre='Negocio propio'))
+        self.assertTrue(Oficio.objects.get(nombre='Comerciante'))
+        self.assertTrue(Oficio.objects.get(nombre='Venta de productos'))
+        self.assertTrue(Oficio.objects.get(nombre='Otro'))
+
+    def test_oficio_estudiante_added(self):
+        """ Check that the option to use estudiante as oficio has been added
+        """
+
+        self.assertTrue(Oficio.objects.get(nombre='Estudiante'))


### PR DESCRIPTION
…ion.

The option has been added through a migration as all the previous options.

#### What's this PR do?
Add the option to select student as an ocupation for a family member

#### Where should the reviewer start?
Check the new migration added in the familias app, and then check the tests created.

#### How should this be manually tested?
Login as a capturista, create or edit a new family member and check that the Estudiante oficio no appears as an option.

#### Any background context you want to provide?
This has been added as per request by stakeholders.


This template was adapted ~stolen~ from [Quickleft/Sprint.ly](https://quickleft.com/blog/pull-request-templates-make-code-review-easier/)