### PR TITLE
Fix presentation of family members in focus mode

### DIFF
--- a/administracion/tests.py
+++ b/administracion/tests.py
@@ -293,16 +293,6 @@ class TestFeedBack(TestCase):
         self.study = Estudio.objects.create(capturista=self.capturista, familia=f1,
                                             status=Estudio.REVISION)
 
-    def test_url(self):
-        """ Check that the url for focus mode of the study exists.
-
-        """
-        self.client.login(username='thelma', password='junipero')
-        test_url_name = 'administracion:focus_mode'
-        response = self.client.get(reverse(test_url_name,
-                                           kwargs={'study_id': self.study.id}), follow=True)
-        self.assertEqual(200, response.status_code)
-
     def test_valid_form(self):
         """ Check that the form is valid with correct data.
 

--- a/administracion/urls.py
+++ b/administracion/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 from .views import admin_users_dashboard, \
                    admin_users_create, admin_users_edit, admin_users_edit_form, \
                    admin_users_delete_modal, admin_users_delete, list_studies, \
-                   focus_mode, search_students, detail_student
+                   search_students, detail_student
 
 app_name = 'administracion'
 
@@ -15,7 +15,6 @@ urlpatterns = [
     url(r'^usuarios/borrar/confirmar/', admin_users_delete, name='users_delete'),
     url(r'^usuarios/', admin_users_dashboard, name='users'),
     url(r'^principal/(?P<status_study>[\w\-]+)/$', list_studies, name='main_estudios'),
-    url(r'^principal/(?P<study_id>[\w\-]+)/detalle', focus_mode, name='focus_mode'),
     url(r'^busqueda/', search_students, name='search_students'),
     url(r'^detalle-alumno/(?P<id_alumno>[0-9]+)', detail_student, name='detail_student'),
 ]

--- a/administracion/views.py
+++ b/administracion/views.py
@@ -9,7 +9,7 @@ from familias.models import Alumno
 from becas.models import Beca
 from becas.forms import CartaForm
 from becas.utils import generate_letter
-from .forms import UserForm, DeleteUserForm, FeedbackForm
+from .forms import UserForm, DeleteUserForm
 
 
 @login_required
@@ -104,22 +104,6 @@ def list_studies(request, status_study):
     contexto = {'estudios': estudios, 'estado': status_study,
                 'status_options': Estudio.get_options_status()}
     return render(request, 'estudios_socioeconomicos/listado_estudios.html', contexto)
-
-
-@login_required
-@user_passes_test(is_administrador)
-def focus_mode(request, study_id):
-    """ View to show the detail of a study.
-
-    TODO: This should be filled with all the info of the study.
-    """
-    context = {}
-    estudio = Estudio.objects.get(pk=study_id)
-    if estudio.status == Estudio.REVISION:
-        feedback_form = FeedbackForm(initial={'estudio': estudio,
-                                              'usuario': request.user})
-        context['feedback_form'] = feedback_form
-    return render(request, 'administracion/focus_mode.html', context)
 
 
 @login_required

--- a/estudios_socioeconomicos/test_views.py
+++ b/estudios_socioeconomicos/test_views.py
@@ -187,7 +187,7 @@ class TestFocusMode(TestCase):
         self.test_url = 'estudios_socioeconomicos:focus_mode'
 
     def test_view_study(self):
-        """ Test that a study can be viewed in focus mode.ew
+        """ Test that a study can be viewed in focus mode.
         """
         self.client.login(username=self.test_username, password=self.test_password)
 
@@ -235,3 +235,23 @@ class TestFocusMode(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTemplateUsed(response, 'estudios_socioeconomicos/focus_mode.html')
+
+    def test_non_active_family_members_invisible(self):
+        """ Test that an inactive family member can't appear inside the focus mode.
+        """
+
+        inactive_member = Integrante.objects.create(
+            familia=self.familia,
+            nombres='Inactive',
+            apellidos='Oddjob',
+            nivel_estudios='doctorado',
+            fecha_de_nacimiento='1996-02-26',
+            activo=False)
+
+        self.client.login(username=self.test_username, password=self.test_password)
+
+        response = self.client.get(reverse(self.test_url, kwargs={'id_estudio': self.estudio.id}))
+        response_text = response.content.decode('utf-8')
+
+        self.assertNotIn(inactive_member.nombres, response_text)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/estudios_socioeconomicos/views.py
+++ b/estudios_socioeconomicos/views.py
@@ -50,7 +50,7 @@ def focus_mode(request, id_estudio):
             Estudio.objects.filter(pk=id_estudio),
             capturista=request.user.capturista)
 
-    integrantes = Integrante.objects.filter(familia=estudio.familia).select_related()
+    integrantes = Integrante.objects.filter(familia=estudio.familia, activo=True).select_related()
     fotos = Foto.objects.filter(estudio=id_estudio)
     context['estudio'] = estudio
     context['integrantes'] = integrantes


### PR DESCRIPTION
#### What's this PR do?
This PR, fixes the presentation of family members inside the focus mode.
Inactive family members no longer appear, when an administrator accesses the focus-mode view.

#### Where should the reviewer start?
Check the corrections to the focus mode view in estudios_socioeconomicos/views


#### How should this be manually tested?
The reviewer should create a new study, create two family members and delete one, then submit the socioeconomical study for review, login as an administrator, go to the Pendientes Section, and then open the focus mode of the pending study. Check that only the family member that wasn't erased appears, on the family member table.

#### Any background context you want to provide?
This is as per request by stakeholders.


This template was adapted ~stolen~ from [Quickleft/Sprint.ly](https://quickleft.com/blog/pull-request-templates-make-code-review-easier/)