### PR TITLE
Allow the use of commas in the amount of ingresos y egresos

### DIFF
--- a/captura/tests.py
+++ b/captura/tests.py
@@ -129,6 +129,23 @@ class TestViewsTransacciones(TestCase):
         self.assertEqual(content['msg'], 'Egreso guardado con éxito')
         self.assertEqual(r.status_code, 200)
 
+    def test_create_egreso_with_comma(self):
+        """ Test that validate that the amount of an egreso can be contains
+        commas and if the other information is correctly provided it will to
+        create successfuly the transaction.
+        """
+        self.transaccion_constructor_dictionary['monto'] = '2,500.00'
+        r = self.client.post(reverse('captura:create_transaccion',
+                                     kwargs={'id_familia': self.familia1.id}),
+                             data=self.transaccion_constructor_dictionary,
+                             HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        content = json.loads(r.content.decode('utf-8'))
+        self.assertEqual(content['msg'], 'Egreso guardado con éxito')
+        self.assertEqual(r.status_code, 200)
+
+        transaccion = Transaccion.objects.filter(familia=self.familia1).last()
+        self.assertEqual(transaccion.monto, 2500)
+
     def test_create_egreso_incomplete(self):
         """ Test that an egreso won't be created if required information is
         incomplete.
@@ -158,6 +175,26 @@ class TestViewsTransacciones(TestCase):
         content = json.loads(r.content.decode('utf-8'))
         self.assertEqual(content['msg'], 'Ingreso guardado con éxito')
         self.assertEqual(r.status_code, 200)
+
+    def test_create_ingreso_with_comma(self):
+        """ Test that validate that the amount of an ingreso can be contains
+        commas and if the other information is correctly provided it will to
+        create successfuly the transaction.
+        """
+        self.transaccion_constructor_dictionary['es_ingreso'] = True
+        self.transaccion_constructor_dictionary['monto'] = '2,500.00'
+        self.ingreso_constructor_dictionary.update(self.transaccion_constructor_dictionary)
+
+        r = self.client.post(reverse('captura:create_transaccion',
+                                     kwargs={'id_familia': self.familia1.id}),
+                             data=self.ingreso_constructor_dictionary,
+                             HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        content = json.loads(r.content.decode('utf-8'))
+        self.assertEqual(content['msg'], 'Ingreso guardado con éxito')
+        self.assertEqual(r.status_code, 200)
+
+        transaccion = Transaccion.objects.filter(familia=self.familia1).last()
+        self.assertEqual(transaccion.monto, 2500)
 
     def test_create_ingreso_incomplete(self):
         """ Test that an ingreso won't be created if the required information is

--- a/captura/views.py
+++ b/captura/views.py
@@ -523,11 +523,17 @@ def update_create_transaccion(request, id_familia):
     """
     if request.is_ajax() and request.method == 'POST':
         response_data = {}
+
+        # Cleaning dor possible commas
+        post = request.POST.copy()
+        if 'monto' in post:
+            post['monto'] = post['monto'].replace(',', '')
+
         if request.POST.get('id_transaccion', None):  # In case of updating
             transaccion = get_object_or_404(Transaccion, pk=request.POST['id_transaccion'])
-            transaccion_form = TransaccionForm(request.POST, instance=transaccion)
+            transaccion_form = TransaccionForm(post, instance=transaccion)
         else:  # In case of creation
-            transaccion_form = TransaccionForm(request.POST)
+            transaccion_form = TransaccionForm(post)
         if transaccion_form.is_valid():
             transaccion_form.save()
             if transaccion_form.cleaned_data['es_ingreso']:


### PR DESCRIPTION
#### What's this PR do?
Allow the use of commas in the amount of ingresos y egresos

#### Where should the reviewer start?
Check the changes on update_create_transaccion, inside captura/views.py. Also check the test test_create_egreso_with_comma and test_create_ingreso_with_comma on TestViewsTransacciones, inside captura/tests.py

#### How should this be manually tested?
Use mozilla or IE, enter to a new socioeconomical study and in "Ingresos y Egresos" section create a new transaction, introducing a number with commas as separetor in monto (i.e. 1,300). The transactions must to be saved successfully

#### Any background context you want to provide?
This has been added as per request by stakeholders.


This template was adapted ~stolen~ from [Quickleft/Sprint.ly](https://quickleft.com/blog/pull-request-templates-make-code-review-easier/)